### PR TITLE
change how a completion passes positioning info

### DIFF
--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -89,10 +89,17 @@ class DartCompleter extends CodeCompleter {
         }
 
         if (completion.type == null) {
-          return new Completion(text, displayString: displayString, parameterCount: completion.parameterCount);
+          return new Completion(text, displayString: displayString);
         } else {
-          return new Completion(text, displayString: displayString, parameterCount: completion.parameterCount,
-              type: "type-${completion.type.toLowerCase()}");
+          int cursorPos = null;
+
+          if (completion.isMethod && completion.parameterCount > 0) {
+            cursorPos = text.indexOf('(') + 1;
+          }
+
+          return new Completion(text, displayString: displayString,
+              type: "type-${completion.type.toLowerCase()}",
+              cursorOffset: cursorPos);
         }
       }).where((x) => x != null).toList();
 

--- a/lib/editing/editor.dart
+++ b/lib/editing/editor.dart
@@ -16,6 +16,7 @@ abstract class EditorFactory {
 
   Editor createFromElement(html.Element element);
 
+  bool get supportsCompletionPositioning;
   // TODO: codemirror gives the client more control over where to insert the
   // completions. With Ace, you can only insert from the requested position
   // forward.
@@ -111,7 +112,6 @@ abstract class CodeCompleter {
   Future<List<Completion>> complete(Editor editor);
 }
 
-// TODO: positions?
 class Completion {
   /// The value to insert.
   final String value;
@@ -119,11 +119,15 @@ class Completion {
   /// An optional string that is displayed during auto-completion if specified.
   final String displayString;
 
+  /// The css class type for the completion. This may not be supported by all
+  /// completors.
   final String type;
 
-  int parameterCount;
+  /// The (optional) offset to display the cursor at after completion. This is
+  /// relative to the insertion location, not the absolute position in the file.
+  /// This may be `null`, and cursor re-positioning may not be supported by all
+  /// completors. See [EditorFactory.supportsCompletionPositioning].
+  final int cursorOffset;
 
-  bool get isMethodWithArguments => parameterCount != null && parameterCount > 0;
-
-  Completion(this.value, {this.displayString, this.type, this.parameterCount});
+  Completion(this.value, {this.displayString, this.type, this.cursorOffset});
 }

--- a/lib/editing/editor_ace.dart
+++ b/lib/editing/editor_ace.dart
@@ -84,11 +84,12 @@ class AceFactory extends EditorFactory {
     return new _AceEditor._(this, editor);
   }
 
+  bool get supportsCompletionPositioning => false;
+
   void registerCompleter(String mode, CodeCompleter completer) {
     // TODO:
 //    ace.LanguageTools langTools = ace.require('ace/ext/language_tools');
 //    langTools.addCompleter(new ace.AutoCompleter(_aceCompleter));
-
   }
 }
 

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -84,6 +84,8 @@ class CodeMirrorFactory extends EditorFactory {
         new CodeMirror.fromElement(element, options: options));
   }
 
+  bool get supportsCompletionPositioning => true;
+
   void registerCompleter(String mode, CodeCompleter completer) {
     Hints.registerHintsHelperAsync(mode, (CodeMirror editor, [HintsOptions options]) {
       return _completionHelper(editor, completer, options);
@@ -103,8 +105,10 @@ class CodeMirrorFactory extends EditorFactory {
             className: completion.type,
             hintApplier: (CodeMirror editor, HintResult hint, pos.Position from, pos.Position to) {
               editor.getDoc().replaceRange(hint.text, from, to);
-              if (completion.isMethodWithArguments) {
-                editor.getDoc().setCursor(new pos.Position(editor.getCursor().line, editor.getCursor().ch - 1));
+              if (completion.cursorOffset != null) {
+                int diff = hint.text.length - completion.cursorOffset;
+                editor.getDoc().setCursor(new pos.Position(
+                    editor.getCursor().line, editor.getCursor().ch - diff));
               }
             }
         );

--- a/lib/editing/editor_comid.dart
+++ b/lib/editing/editor_comid.dart
@@ -90,6 +90,8 @@ class ComidFactory extends EditorFactory {
   CodeCompleter completer;
   String completoinMode;
 
+  bool get supportsCompletionPositioning => false;
+
   void registerCompleter(String mode, CodeCompleter codeCompleter) {
     options = new hints.CompletionOptions(
         hint: computeProposals,


### PR DESCRIPTION
@kasperpeulen, some tweaks to your PR for completion cursor positioning:
- let the different text editor wrappers (codemirror, comid, ace) tell us whether their completions can support cursor positioning
- have each created completion contain the best cursor position for itself (`cursorOffset`)
